### PR TITLE
Background color

### DIFF
--- a/src/scss/_default-config.scss
+++ b/src/scss/_default-config.scss
@@ -308,6 +308,8 @@ $_theme: map-merge(
     (text-color: $colors,)
 );
 
+$theme: $_theme !default;
+
 $variant-order: (
   first,
   last,

--- a/src/scss/_default-config.scss
+++ b/src/scss/_default-config.scss
@@ -351,4 +351,7 @@ $variants: (
     box-sizing: default responsive,
     display: default responsive,
     text-color: default responsive,
+    text-opacity: default responsive,
+    background-color: default responsive,
+    background-opacity: default responsive,
 ) !default;

--- a/src/scss/_default-config.scss
+++ b/src/scss/_default-config.scss
@@ -305,7 +305,27 @@ $_theme: map-merge(
 
 $_theme: map-merge(
     $_theme,
-    (text-color: $colors,)
+    (colors: $colors,)
+);
+
+$_theme: map-merge(
+    $_theme,
+    (text-color: map-get($_theme, colors),)
+);
+
+$_theme: map-merge(
+    $_theme,
+    (text-opacity: map-get($_theme, opacity),)
+);
+
+$_theme: map-merge(
+    $_theme,
+    (background-color: map-get($_theme, colors),)
+);
+
+$_theme: map-merge(
+    $_theme,
+    (background-opacity: map-get($_theme, opacity),)
 );
 
 $theme: $_theme !default;

--- a/src/scss/_default-config.scss
+++ b/src/scss/_default-config.scss
@@ -264,17 +264,49 @@ $colors: (
     "transparent": transparent,
 ) !default;
 
-$theme: (
-    colors: $colors,
-    screens: (
+$_theme: map-remove((x: x,), x);
+
+$_theme: map-merge(
+    $_theme,
+    (colors: $colors,)
+);
+
+$_theme: map-merge(
+    $_theme,
+    (opacity: (
+        0: '0',
+        5: '0.05',
+        10: '0.1',
+        20: '0.2',
+        25: '0.25',
+        30: '0.3',
+        40: '0.4',
+        50: '0.5',
+        60: '0.6',
+        70: '0.7',
+        75: '0.75',
+        80: '0.8',
+        90: '0.9',
+        95: '0.95',
+        100: '1',
+    ),)
+);
+
+$_theme: map-merge(
+    $_theme,
+    (screens: (
         sm: 640px,
         md: 768px,
         lg: 1024px,
         xl: 1280px,
         xxl: 1536px,
-    ),
-    text-color: $colors,
-) !default;
+    ),)
+);
+
+$_theme: map-merge(
+    $_theme,
+    (text-color: $colors,)
+);
 
 $variant-order: (
   first,

--- a/src/scss/_default-plugins.scss
+++ b/src/scss/_default-plugins.scss
@@ -1,9 +1,15 @@
 @use "plugins/display" as *;
 @use "plugins/text-color" as *;
+@use "plugins/text-opacity" as *;
+@use "plugins/background-color" as *;
+@use "plugins/background-opacity" as *;
 @use "plugins/box-sizing" as *;
 
 $plugins: (
     box-sizing: $box-sizing-plugin,
     display: $display-plugin,
     text-color: $text-color-plugin,
+    text-opacity: $text-opacity-plugin,
+    background-color: $background-color-plugin,
+    background-opacity: $background-opacity-plugin,
 );

--- a/src/scss/plugins/_background-color.scss
+++ b/src/scss/plugins/_background-color.scss
@@ -8,7 +8,7 @@ $_background-color-plugin: map-remove((x: x,), x);
         (
             name-class('bg', $key): (
                 --mh-bg-opacity: 1,
-                background-color: rgba($value, var(--mh-bg-opacity)),
+                background-color: if(map-has-key($theme, background-opacity) , rgba($value, var(--mh-bg-opacity)) , $value),
             ),
         )
     );

--- a/src/scss/plugins/_background-color.scss
+++ b/src/scss/plugins/_background-color.scss
@@ -1,0 +1,17 @@
+@use '../util/name-class' as *;
+@use '../config' as *;
+$_background-color-plugin: map-remove((x: x,), x);
+
+@each $key, $value in map-get($theme, background-color) {
+    $_background-color-plugin: map-merge(
+        $_background-color-plugin,
+        (
+            name-class('bg', $key): (
+                --mh-bg-opacity: 1,
+                background-color: rgba($value, var(--mh-bg-opacity)),
+            ),
+        )
+    );
+}
+
+$background-color-plugin: $_background-color-plugin !default;

--- a/src/scss/plugins/_background-opacity.scss
+++ b/src/scss/plugins/_background-opacity.scss
@@ -1,0 +1,16 @@
+@use '../util/name-class' as *;
+@use '../config' as *;
+$_background-opacity-plugin: map-remove((x: x,), x);
+
+@each $key, $value in map-get($theme, background-opacity) {
+    $_background-opacity-plugin: map-merge(
+        $_background-opacity-plugin,
+        (
+            name-class('bg-opacity', $key): (
+                --mh-bg-opacity: #{$value},
+            ),
+        )
+    );
+}
+
+$background-opacity-plugin: $_background-opacity-plugin !default;

--- a/src/scss/plugins/_text-color.scss
+++ b/src/scss/plugins/_text-color.scss
@@ -8,7 +8,7 @@ $_text-color-plugin: map-remove((x: x,), x);
         (
             name-class('text', $key): (
                 --mh-text-opacity: 1,
-                color: rgba($value, var(--mh-text-opacity)),
+                color: if(map-has-key($theme, text-opacity) , rgba($value, var(--mh-text-opacity)) , $value),
             ),
         )
     );

--- a/src/scss/plugins/_text-opacity.scss
+++ b/src/scss/plugins/_text-opacity.scss
@@ -1,0 +1,16 @@
+@use '../util/name-class' as *;
+@use '../config' as *;
+$_text-opacity-plugin: map-remove((x: x,), x);
+
+@each $key, $value in map-get($theme, text-opacity) {
+    $_text-opacity-plugin: map-merge(
+        $_text-opacity-plugin,
+        (
+            name-class('text-opacity', $key): (
+                --mh-text-opacity: #{$value},
+            ),
+        )
+    );
+}
+
+$text-opacity-plugin: $_text-opacity-plugin !default;


### PR DESCRIPTION
Added background color classes

**Syntax**
```css
// default
bg-[ color ]

// responsive
[sm | md | lg | xl | xxl ]:bg-[ color ]
```
256 Material Design colors and transparent color supported.

Added background opacity classes
**Syntax**
```css
// default
bg-opacity[ value ]

// responsive
[sm | md | lg | xl | xxl ]:bg-opacity-[ value ]
```
