### PR TITLE
Position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -686,9 +686,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001207",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
-      "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
+      "version": "1.0.30001208",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
+      "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
       "dev": true
     },
     "caseless": {

--- a/src/scss/plugins/_position.scss
+++ b/src/scss/plugins/_position.scss
@@ -1,0 +1,12 @@
+$position-plugin: map-remove((x: x,), x);
+
+@each $value in (static fixed absolute relative sticky){
+    $position-plugin: map-merge(
+        $position-plugin,
+        (
+            $value: (
+                position: $va;ue,
+            ),
+        )
+    );
+}


### PR DESCRIPTION

# Description

**Utilities for controlling how an element is positioned in the DOM.**


Class|Properties
-|-
static|position: static;
fixed|position: fixed;
absolute|position: absolute;
relative|position: relative;
sticky|position: sticky;

## Static

Use  `static`  to position an element according to the normal flow of the document.

Any offsets will be ignored and the element will not act as a position reference for absolutely positioned children.

```html
<div class="static ...">
  <p>Static parent</p>
  <div class="absolute bottom-0 left-0 ...">
    <p>Absolute child</p>
  </div>
</div>
```

## Relative

Use  `relative`  to position an element according to the normal flow of the document.

Offsets are calculated relative to the element's normal position and the element  _will_  act as a position reference for absolutely positioned children.

```html
<div class="relative ...">
  <p>Relative parent</p>
  <div class="absolute bottom-0 left-0 ...">
    <p>Absolute child</p>
  </div>
</div>
```

## Absolute

Use  `absolute`  to position an element  _outside_  of the normal flow of the document, causing neighboring elements to act as if the element doesn't exist.

Offsets are calculated relative to the nearest parent that has a position other than  `static`, and the element  _will_  act as a position reference for other absolutely positioned children.

```html
<div class="static ...">
  <!-- Static parent -->
  <div class="static ..."><p>Static child</p></div>
  <div class="inline-block ..."><p>Static sibling</p></div>
  <!-- Static parent -->
  <div class="absolute ..."><p>Absolute child</p></div>
  <div class="inline-block ..."><p>Static sibling</p></div>
</div>
```

## Fixed

Use  `fixed`  to position an element relative to the browser window.

Offsets are calculated relative to the viewport and the element  _will_  act as a position reference for absolutely positioned children.


```html
<div>
  <div class="fixed ...">
    Fixed child
  </div>

  Scroll me!

  Lorem ipsum...
</div>
```

## Sticky

Use  `sticky`  to position an element as  `relative`  until it crosses a specified threshold, then treat it as fixed until its parent is off screen.

Offsets are calculated relative to the element's normal position and the element  _will_  act as a position reference for absolutely positioned children.


```html
<div>
  <div class="sticky top-0 ...">Sticky Heading 1</div>
  <p class="py-4">Quisque cursus...</p>
</div>
<div>
  <div class="sticky top-0 ...">Sticky Heading 2</div>
  <p class="py-4">Integer lacinia...</p>
</div>
<div>
  <div class="sticky top-0 ...">Sticky Heading 3</div>
  <p class="py-4">Nullam mauris...</p>
</div>
<!-- etc. -->
```

## Responsive

To change how an element is positioned only at a specific breakpoint, add a  `{screen}:`  prefix to any existing position utility. For example, adding the class  `md:absolute`  to an element would apply the  `absolute`  utility at medium screen sizes and above.

```html
<div class="relative h-32 ...">
  <div class="inset-x-0 bottom-0 relative md:absolute"></div>
</div>
```


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Help wanted(need more help to complete pull request)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
